### PR TITLE
Fixed Flash exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ soft/hex/
 
 # OS generated folders
 .DS_Store/
+8809DataSheet.md

--- a/soft/platform/chip/hal/src/hal_spi_flash.c
+++ b/soft/platform/chip/hal/src/hal_spi_flash.c
@@ -245,8 +245,30 @@ static uint32_t hal_SpiCmdWithRx(uint8_t cmd, bool qread, const uint8_t *txdata,
         result |= (hwp_spiFlash->spi_data_fifo_wo & 0xff) << 24;
 #endif
 
+// #ifdef SPI_RX_USE_READBACK
+//     uint32_t result = hwp_spiFlash->spi_read_back >> ((4 - rxsize) * 8);
+//     SPI_SET_RX_TX_SIZE(0);
+// #endif
 #ifdef SPI_RX_USE_READBACK
-    uint32_t result = hwp_spiFlash->spi_read_back >> ((4 - rxsize) * 8);
+    #ifdef CHIP_DIE_8809
+        // For 8809, handle byte replication
+        uint32_t result = 0;
+        // Read first byte
+        result |= (hwp_spiFlash->spi_read_back & 0xFF);
+        // Read subsequent bytes
+        if (rxsize > 1) {
+            result |= (hwp_spiFlash->spi_read_back & 0xFF) << 8;
+        }
+        if (rxsize > 2) {
+            result |= (hwp_spiFlash->spi_read_back & 0xFF) << 16;
+        }
+        if (rxsize > 3) {
+            result |= (hwp_spiFlash->spi_read_back & 0xFF) << 24;
+        }
+    #else
+        // Original code for 8955 and others
+        uint32_t result = hwp_spiFlash->spi_read_back >> ((4 - rxsize) * 8);
+    #endif
     SPI_SET_RX_TX_SIZE(0);
 #endif
 


### PR DESCRIPTION
Fix: Flash readback register issue on 8809

On the 8955 platform, a single `read_back` register call retrieves the full 32-bit data (one call is sufficient). However, on the 8809 platform, `read_back` can only load 8 bytes at a time. It then replicates that 8-byte value 4 times to simulate a 32-bit word, which results in incorrect data if not handled properly.

This commit introduces logic to:
- Call `read_back` multiple times on 8809, depending on the expected RX size.
- Accumulate and shift the individual 8-byte chunks to reconstruct the correct 32-bit value.
- Mirror the behavior already implemented for 8809E2 (as seen in the FIFO handling code).

This ensures consistent and accurate data retrieval across platforms with different readback capabilities.
